### PR TITLE
feat: support breaking change commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Then, create a `template.md` file in your project root directory.
 
 %% commits %%
 
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ toSentence(message) }} (#{{ prNumber }})
+- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
 %% commits %%
 %% changes %%
 <!-- Generate by Release Note -->

--- a/__tests__/generator/expression-evaluator.test.ts
+++ b/__tests__/generator/expression-evaluator.test.ts
@@ -8,6 +8,11 @@ describe("ExpressionEvaluator test", () => {
       expect(evaluator.evaluate("a")).toBe("1");
       expect(evaluator.evaluate("b")).toBe("2");
     });
+    test("Evaluate a boolean variable", () => {
+      const evaluator = new ExpressionEvaluator({ a: true, b: false });
+      expect(evaluator.evaluate("a")).toBe(true);
+      expect(evaluator.evaluate("b")).toBe(false);
+    });
     test("Evaluate a non-existent variable", () => {
       const evaluator = new ExpressionEvaluator({});
       expect(() => evaluator.evaluate("a")).toThrowError();

--- a/__tests__/generator/generator.test.ts
+++ b/__tests__/generator/generator.test.ts
@@ -25,7 +25,7 @@ const template = `## 📝 Changelog
 ### {{ title }}
 
 %% commits %%
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ message }} (#{{ prNumber }})
+- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ message }} (#{{ prNumber }})
 %% commits %%
 %% changes %%
 <!-- Generate by Release Note -->
@@ -124,5 +124,79 @@ describe("Generator test", () => {
 - docs: update README.md (#1)
 <!-- Generate by Release Note -->
 `);
+  });
+  test("Generate with commit contains breaking change", () => {
+    const generator = new Generator(
+      [
+        {
+          hash: "d49b398cfca0376c83adb89d25df18f857b901e7",
+          parents:
+            "88d9f36e8aef3f4ecd043511ec5a871775d6c1a5 167616ac2a9defb49e149757f4a865330cec2c4f",
+          date: "2022-11-25T19:15:00+08:00",
+          message: "feat!: edit existed feature (#1)",
+          refs: "HEAD -> master, upstream/master, origin/master, origin/HEAD",
+          body: "",
+          commiterName: "GitHub",
+          commiterEmail: "noreply@github.com",
+          authorName: "ppodds",
+          authorEmail: "oscar20020629@gmail.com",
+        },
+      ],
+      {
+        prTypes: [{ identifier: "feat", title: "🚀 Enhancements" }],
+        template,
+        metadata,
+      },
+    );
+    expect(generator.generate()).toBe(`## 📝 Changelog
+
+### 🚀 Enhancements
+
+- ⚠️ edit existed feature (#1)
+<!-- Generate by Release Note -->
+`);
+  });
+  test("Generate boolean type variable", () => {
+    const generator = new Generator(
+      [
+        {
+          hash: "d49b398cfca0376c83adb89d25df18f857b901e7",
+          parents:
+            "88d9f36e8aef3f4ecd043511ec5a871775d6c1a5 167616ac2a9defb49e149757f4a865330cec2c4f",
+          date: "2022-11-25T19:15:00+08:00",
+          message: "feat!: edit existed feature (#1)",
+          refs: "HEAD -> master, upstream/master, origin/master, origin/HEAD",
+          body: "",
+          commiterName: "GitHub",
+          commiterEmail: "noreply@github.com",
+          authorName: "ppodds",
+          authorEmail: "oscar20020629@gmail.com",
+        },
+        {
+          hash: "d49b398cfca0376c83adb89d25df18f857b901e7",
+          parents:
+            "88d9f36e8aef3f4ecd043511ec5a871775d6c1a5 167616ac2a9defb49e149757f4a865330cec2c4f",
+          date: "2022-11-25T19:15:00+08:00",
+          message: "feat: add a new feature (#2)",
+          refs: "HEAD -> master, upstream/master, origin/master, origin/HEAD",
+          body: "",
+          commiterName: "GitHub",
+          commiterEmail: "noreply@github.com",
+          authorName: "ppodds",
+          authorEmail: "oscar20020629@gmail.com",
+        },
+      ],
+      {
+        prTypes: [{ identifier: "feat", title: "🚀 Enhancements" }],
+        template: `%% changes %%
+%% commits %%
+{{ prBreaking }}
+%% commits %%
+%% changes %%
+`,
+        metadata,
+      },
+    );
+    expect(generator.generate()).toBe("true\nfalse\n");
   });
 });

--- a/__tests__/generator/macro.test.ts
+++ b/__tests__/generator/macro.test.ts
@@ -29,4 +29,12 @@ describe("Macros test", () => {
     expect(macros.formatDate("2015-03-10T14:09:18Z", "YYYY-MM-DD"));
     expect(() => macros.formatDate("aaa", "YYYY-MM-DD")).toThrowError();
   });
+  test("generateIf", () => {
+    expect(macros.generateIf(true, "test")).toBe("test");
+    expect(macros.generateIf(false, "test")).toBe("");
+  });
+  test("generateIfNot", () => {
+    expect(macros.generateIfNot(true, "test")).toBe("");
+    expect(macros.generateIfNot(false, "test")).toBe("test");
+  });
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,15 +142,15 @@ generateIfNotEmpty("a", "test"); // test
 
 #### generateIfEmpty
 
-Signature: `generateIfNotEmpty(toBeCheck: string, content: string)`
+Signature: `generateIfEmpty(toBeCheck: string, content: string)`
 
 Generate content if the string is empty.
 
 Examples:
 
 ```typescript
-generateIfNotEmpty("", "test"); // test
-generateIfNotEmpty("a", "test"); // generate nothing
+generateIfEmpty("", "test"); // test
+generateIfEmpty("a", "test"); // generate nothing
 ```
 
 #### formatDate
@@ -164,6 +164,32 @@ Examples:
 ```typescript
 // publishedAt = "2022-01-01T00:00:00Z"
 formatDate(publishedAt, "YYYY-MM-DD"); // 2022-01-01
+```
+
+#### generateIfNot
+
+Signature: `generateIfNot(condition: boolean, content: string)`
+
+Generate content if the condition is `false`.
+
+Examples:
+
+```typescript
+generateIfNot(true, "test"); // generate nothing
+generateIfNot(false, "test"); // test
+```
+
+#### generateIf
+
+Signature: `generateIf(condition: string, content: string)`
+
+Generate content if the condition is `true`.
+
+Examples:
+
+```typescript
+generateIf(true, "test"); // test
+generateIf(false, "test"); // generate nothing
 ```
 
 ### Variables
@@ -246,6 +272,10 @@ If the variable is not defined in the context and you use it, it will throw an e
 - `prSubtype`
   - pull request subtype (extracted from commit message)
   - e.g. `docs(test): a test (#1)` => `test`
+- `prBreaking`
+  - if the pull request is breaking change
+  - return **boolean** value, if you use it in template directly, it will be `true` or `false`
+  - e.g. `feat!: breaking change (#1)` => `true`
 - `prNumber`
   - pull request number (extracted from commit message)
   - e.g. `docs: a test (#1)` => `1`

--- a/src/generator/expression-evaluator.ts
+++ b/src/generator/expression-evaluator.ts
@@ -1,7 +1,7 @@
 import { macros } from "./macros";
 
 export interface Variable {
-  [key: string]: string | undefined;
+  [key: string]: string | boolean | undefined;
 }
 
 export class ExpressionEvaluator {
@@ -15,7 +15,7 @@ export class ExpressionEvaluator {
    * @param expression The expression to evaluate
    * @returns evaluated expression
    */
-  public evaluate(expression: string): string {
+  public evaluate(expression: string): string | boolean {
     const macroRegex = /([A-Za-z0-9]+)\(([^\n]*)\)/;
     const matchResult = expression.match(macroRegex);
     // is a variable or a string literal
@@ -25,9 +25,12 @@ export class ExpressionEvaluator {
       const parsedVariable = this._variable[expression];
       if (parsedVariable === undefined)
         throw new Error(`Unsupport variable: ${expression}`);
-      if (typeof parsedVariable !== "string")
+      if (
+        typeof parsedVariable !== "string" &&
+        typeof parsedVariable !== "boolean"
+      )
         throw new Error(
-          `Parsed variable is not a string, it should never happen: parsed variable is a ${typeof parsedVariable}`,
+          `Parsed variable is not a string or boolean, it should never happen: parsed variable is a ${typeof parsedVariable}`,
         );
       return parsedVariable;
     }
@@ -55,7 +58,7 @@ export class ExpressionEvaluator {
   private evaluateMacro(macroName: string, macroArgs: string): string {
     const macro = (
       macros as {
-        [x: string]: ((...args: string[]) => string) | undefined;
+        [x: string]: ((...args: (string | boolean)[]) => string) | undefined;
       }
     )[macroName];
     if (macro === undefined) throw new Error(`Unsupport macro: ${macroName}`);

--- a/src/generator/macros.ts
+++ b/src/generator/macros.ts
@@ -21,4 +21,8 @@ export const macros = {
       throw new Error(`Invalid date string: ${dateStr}`);
     return date.format(dateObj, format);
   },
+  generateIf: (condition: boolean, content: string): string =>
+    condition ? content : "",
+  generateIfNot: (condition: boolean, content: string): string =>
+    !condition ? content : "",
 };

--- a/template.md
+++ b/template.md
@@ -6,7 +6,7 @@
 ### {{ title }}
 
 %% commits %%
-- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ toSentence(message) }} (#{{ prNumber }})
+- {{ prSubtype }}{{ generateIfNotEmpty(prSubtype, ": ") }}{{ generateIf(prBreaking, "⚠️ ") }}{{ toSentence(message) }} (#{{ prNumber }})
 %% commits %%
 %% changes %%
 <!-- Generate by Release Note -->


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#19 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Support breaking change commit message. Now the program can detect which pull request is a breaking change and inject it into `prBreaking` variable. This PR also adds two macros to handle the boolean variable. (`generateIf` and `generateIfNot`).
Closes #19.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
