### PR TITLE
feat: allow custom PR type filter

### DIFF
--- a/__tests__/data/commits.ts
+++ b/__tests__/data/commits.ts
@@ -257,4 +257,17 @@ export const commits: readonly Commit[] = [
     authorName: "ppodds",
     authorEmail: "oscar20020629@gmail.com",
   },
+  {
+    hash: "f4da3dfb2fecf0adc21eec883976c652dc3713e2",
+    parents:
+      "49067b1a9efa7fded46d6c4d8747aac9529cdb52 0f7990a7373d34d1b951be459e37333d116d821d",
+    date: "2022-11-22T14:08:57+08:00",
+    message: "feat!: breaking change feature (#987)",
+    refs: "",
+    body: "",
+    commiterName: "GitHub",
+    commiterEmail: "noreply@github.com",
+    authorName: "ppodds",
+    authorEmail: "oscar20020629@gmail.com",
+  },
 ];

--- a/__tests__/generator/generator.test.ts
+++ b/__tests__/generator/generator.test.ts
@@ -34,6 +34,14 @@ describe("Generator test", () => {
   test("Generate a release note", () => {
     const generator = new Generator(commits, {
       prTypes: [
+        {
+          identifier: "breaking",
+          title: "⚠️ Breaking Changes",
+          filter: (_, commit) =>
+            commit.message.match(
+              /([^()\n!]+)(?:\(.*\))?!: .+ \(#[1-9][0-9]*\)/,
+            ) !== null,
+        },
         { identifier: "feat", title: "🚀 Enhancements" },
         { identifier: "fix", title: "🩹 Fixes" },
         { identifier: "docs", title: "📖 Documentation" },
@@ -46,10 +54,15 @@ describe("Generator test", () => {
     });
     expect(generator.generate()).toBe(`## 📝 Changelog
 
+### ⚠️ Breaking Changes
+
+- ⚠️ breaking change feature (#987)
+
 ### 🚀 Enhancements
 
 - frontend: list UI improvement (#212)
 - search engine friendly CoursesSearch (#199)
+- ⚠️ breaking change feature (#987)
 
 ### 🩹 Fixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,10 +32,10 @@ The path to your template file.
 
 `prTypes`
 
-type: `{ "identifier": string, "title": string }[]`  
+type: `{ "identifier": string, "title": string, "filter"?: (prType: PRType, commit: Commit) => boolean; }[]`  
 required: yes
 
-Define which pull request should be included in the release note and how to generate the title.
+Define which pull request should be included in the release note and how to generate the title. `filter` is useful when you want to set a condition to include the pull request. `prType` and `commit` is the parameter of the `filter` function. They can be used to check the pull request type and commit message. Allow you to write your custom filter logic.
 
 ## Template Syntax
 

--- a/release-note.ts
+++ b/release-note.ts
@@ -1,6 +1,13 @@
 export default {
   template: "template.md",
   prTypes: [
+    {
+      identifier: "breaking",
+      title: "⚠️ Breaking Changes",
+      filter: (_: any, commit: any) =>
+        commit.message.match(/([^()\n!]+)(?:\(.*\))?!: .+ \(#[1-9][0-9]*\)/) !==
+        null,
+    },
     { identifier: "feat", title: "🚀 Enhancements" },
     { identifier: "fix", title: "🩹 Fixes" },
     { identifier: "docs", title: "📖 Documentation" },

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -45,14 +45,17 @@ export class Generator {
     if (this._data.length !== 0) this._data.splice(0, this._data.length);
     // gererate necessary information
     for (const prType of this._options.prTypes) {
-      const commits = this._log.filter(
-        (commit) =>
-          commit.parents.split(" ").length > 1 &&
+      const filter =
+        prType.filter ??
+        ((type: PRType, commit: Commit) =>
           commit.message.match(
             new RegExp(
-              `${prType.identifier}(?:\\(.*\\))?!?: .+ \\(#[1-9][0-9]*\\)`,
+              `${type.identifier}(?:\\(.*\\))?!?: .+ \\(#[1-9][0-9]*\\)`,
             ),
-          ),
+          ) !== null);
+      const commits = this._log.filter(
+        (commit) =>
+          commit.parents.split(" ").length > 1 && filter(prType, commit),
       );
       this._data.push({ prType, commits });
     }

--- a/src/generator/pr-type.ts
+++ b/src/generator/pr-type.ts
@@ -1,4 +1,7 @@
+import { Commit } from "../git/log";
+
 export interface PRType {
   identifier: string;
   title: string;
+  filter?: (prType: PRType, commit: Commit) => boolean;
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Allow users to set a custom filter to control which pull request they want to include.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
